### PR TITLE
Fixed nullpointer when no user is logged in

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -139,7 +139,7 @@ class Plugin extends PluginBase {
 
 	public static function getUser() {
 		$user = Auth::getUser();
-		if (!$user->is_activated) {
+		if (!$user || !$user->is_activated) {
 			return false;
 		}
 		return $user;


### PR DESCRIPTION
The recent changes in commit 4fdd6213715a12262b1397ff5bb57f2b08e5ea74 introduce a bug when trying to check permissions, while no user is logged in. This results in the error message "Trying to get property of non-object".
I fixed that by checking in Plugin::getUser if october's Auth class returned a user at all.