### PR TITLE
Update create_tables.php

### DIFF
--- a/updates/create_tables.php
+++ b/updates/create_tables.php
@@ -12,7 +12,7 @@ class CreateTables extends Migration
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
-            $table->string('description')->nulable();
+            $table->string('description')->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
Minor typo, ->nullable() was mispelled as ->nulable().
Doesn't seem to hurt anything since October inserts an empty string regardless if nothing is entered for the description, but should probably be corrected.